### PR TITLE
update meta label to fit inside footer

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -44,5 +44,8 @@
           </div>
         </div>
       </div>
+      {% if jekyll.environment == 'staging' %}
+        {% include _env-indicator.html %}
+      {% endif %}
     </div>
   </footer>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -43,10 +43,6 @@
 
 {% include _footer.html %}
 
-{% if jekyll.environment == 'staging' %}
-{% include _env-indicator.html %}
-{% endif %}
-
       <script src="/assets/uswds/js/uswds.min.js" async></script>
       <script src="/assets/js/app.js" async></script>
   </body>


### PR DESCRIPTION
## summary of changes

A piece of markup we insert on staging-environment builds fell outside of the footer markup. This PR moves it back into the footer section.

Screenshot of correction (footer):
<img src='https://user-images.githubusercontent.com/31673962/101226723-650dd680-3663-11eb-9b9b-fd874a645d90.png' width=300/>